### PR TITLE
Open pull requests

### DIFF
--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -180,9 +180,9 @@ jobs:
             - name: 'Push'
               run: |
                 python -m poetry run doit push:${{ matrix.template }}
-    #         - name: 'Open pull request'
-    #           run: |
-    #               curl -s --location --request POST --header "Authorization: Bearer $GITHUB_TOKEN" \
-    #                 --header 'Content-Type: application/json' \
-    #                 --data-raw '{"head": "update", "base": "master", "title": "auto-updates"}' \
-    #                 https://api.github.com/repos/$GITHUB_REPOSITORY/pulls
+            - name: 'Open pull request'
+              run: |
+                  curl -s --location --request POST --header "Authorization: Bearer $GITHUB_TOKEN" \
+                    --header 'Content-Type: application/json' \
+                    --data-raw '{"head": "update", "base": "master", "title": "auto-updates"}' \
+                    https://api.github.com/repos/platformsh-templates/${{ matrix.template }}/pulls


### PR DESCRIPTION
### Template-builder auto-updates (internal)

**DONE**
- [x] Get list of templates (subdirectories in `templates`), and pass to `strategy.matrix.template` so task can be applied to all templates
- [x] Provide a way to temporarily exclude templates from that list during testing (**this currently excludes everything except for Hugo (Basic) and Drupal9 (Remote)**)
- [x] Run update commands (dependencies, upstream pull, platformify, merge) for a given template
- [x] Push to the template repository `update` branch
- [x] Open pull request from template repo `update` branch. Current commented out version fails, even though it works locally:

1. https://github.com/platformsh-templates/hugo/pull/14
2. https://github.com/platformsh-templates/drupal9/pull/38

---

**TODO**
- [ ] Verify tests on template have passed.
- [ ] **Efficiency:** can we split of poetry/CLI downloads to a separate job, so they aren't downloaded for each template?
- [ ] **Clarity:** This all needs very good comments so others can follow along and improve upon.
- [ ] Automerge a pull request on pass.
- [ ] Move to/test on all templates. There are a few "pseudo-remote" templates that could be an issue here. (i.e. gatsby, strapi, and nuxtjs are created via `npx` rather than a true upstream). Maybe for Multi-app
- [ ] Run on scheduled cron. 

### External source operations/self-update testing

**TODO**
- [ ] Add `update_dependencies` source operation to templates.
- [ ] Parallel update/test workflow to test user-facing source operation, restricted to `development` environment type. See [Directus template scripts](https://github.com/platformsh-templates/directus/tree/master/.platform-scripts/template) for reference. 
- [ ] Include (in README) a user-facing way of handling upstream source-op? (Paul WP/Drupal work)

### Better updates

**TODO**
- [ ] Method for multi-apps to use upstreams

### Future of `files`

Currently, updating a template meant

- cloning the default branch of a template repo into `templates/TEMPLATE/build`
- Cloning the "latest tag" of the upstream remote for that template, where there is a matching `project` class defined
- copying the contents of `templates/TEMPLATE/files` into `templates/TEMPLATE/build`, which contains P.sh configuration files, `.environment` files, etc.
- Applying patches included in `templates/TEMPLATE/`

This made contributions difficult, and not without some friction. An update to `platformsh-templates/TEMPLATE` **had** to be run through template-builder. That way, we could be sure that the contents of `template/TEMPLATE/files` and what showed up in the template were identical. Accepting a PR on `platformsh-templates/TEMPLATE` was not enough, because we needed a way for those changes to also be in template-builder, so that updates were not overwritten on the following update through TB. 

This workflow is not good, so the direct option is to remove the `files` concept from template-builder. That way we can accept contributions on the template repo, and rely on the initial clone step alone. 

Problem is, `templates/TEMPLATE/files` gave us a good place to direct people to with migration instructions. Go look at `template/TEMPLATE/files`, and the `project` defined for the template, and you'll see all of the individual changes you should make to your existing TEMPLATE_STACK repo to deploy on P.sh. 

Especially as we move towards composability & `platformify`, we still need some kind of `diff` that can be applied in this way, so it's not as easy as just *removing* `files`.

### Shared files

**TODO**
See [Directus template scripts](https://github.com/platformsh-templates/directus) for most of these:
- [ ] Some concept of shared files on templates, used by template-buider.
- [ ] `CONTRIBUTING.md`
- [ ] `CODE_OF_CONDUCT.md`
- [ ] `github/ISSUE_TEMPLATES`
- [ ] `.github/PULL_REQUEST_TEMPLATE`
- [ ] `.github/workflows/cla.yaml`
- [ ] Integrate shared files into existing auto-update maintenance process

### Visibility

- [ ] Automatic PR/merge process for template metadata used in marketplace/catalog
- [ ] Include `templates-external` in above process
- [ ] Catalog creation?
- [ ] **Changelog:** List changes made by template-builder, and reuse template repo Wiki as a changelog with each update as a new page. Should this be where Contibuting/Code of Conduct lives as well? See [Pauls playground](https://github.com/gilzow/actions-playground/wiki/changelog)

### Monitoring

- [ ] Slack notifications for template update failures?

